### PR TITLE
do not use sudo when use_sudo is false

### DIFF
--- a/lib/misc.rb
+++ b/lib/misc.rb
@@ -7,3 +7,7 @@ def loadFile file
 		exit 1
 	end
 end
+
+def sudo
+  use_sudo ? "sudo" : ""
+end

--- a/lib/tasks.rb
+++ b/lib/tasks.rb
@@ -4,21 +4,21 @@ namespace :shared do
 	end
 	task :make_symlinks do
 		run "if [ ! -h #{release_path}/shared ]; then ln -s #{shared_path}/files/ #{release_path}/shared; fi"
-		run "for p in `find -L #{release_path} -type l`; do t=`readlink $p | grep -o 'shared/.*$'`; sudo mkdir -p #{release_path}/$t; sudo chown www-data:www-data #{release_path}/$t; done"
+		run "for p in `find -L #{release_path} -type l`; do t=`readlink $p | grep -o 'shared/.*$'`; #{use_sudo ? "sudo" : ""} mkdir -p #{release_path}/$t; #{use_sudo ? "sudo" : ""} chown www-data:www-data #{release_path}/$t; done"
 	end
 end
 
 namespace :nginx do
 	desc "Restarts nginx"
 	task :restart do
-		run "sudo /etc/init.d/nginx restart"
+		run "#{use_sudo ? "sudo" : ""} /etc/init.d/nginx restart"
 	end
 end
 
 namespace :phpfpm do
   desc" Restarts PHP-FPM"
   task :restart do
-    run "sudo /etc/init.d/php-fpm restart"
+    run "#{use_sudo ? "sudo" : ""} /etc/init.d/php-fpm restart"
   end
 end
 

--- a/lib/tasks.rb
+++ b/lib/tasks.rb
@@ -4,21 +4,21 @@ namespace :shared do
 	end
 	task :make_symlinks do
 		run "if [ ! -h #{release_path}/shared ]; then ln -s #{shared_path}/files/ #{release_path}/shared; fi"
-		run "for p in `find -L #{release_path} -type l`; do t=`readlink $p | grep -o 'shared/.*$'`; #{use_sudo ? "sudo" : ""} mkdir -p #{release_path}/$t; #{use_sudo ? "sudo" : ""} chown www-data:www-data #{release_path}/$t; done"
+		run "for p in `find -L #{release_path} -type l`; do t=`readlink $p | grep -o 'shared/.*$'`; #{sudo} mkdir -p #{release_path}/$t; #{use_sudo ? "sudo" : ""} chown www-data:www-data #{release_path}/$t; done"
 	end
 end
 
 namespace :nginx do
 	desc "Restarts nginx"
 	task :restart do
-		run "#{use_sudo ? "sudo" : ""} /etc/init.d/nginx restart"
+		run "#{sudo} /etc/init.d/nginx restart"
 	end
 end
 
 namespace :phpfpm do
   desc" Restarts PHP-FPM"
   task :restart do
-    run "#{use_sudo ? "sudo" : ""} /etc/init.d/php-fpm restart"
+    run "#{sudo} /etc/init.d/php-fpm restart"
   end
 end
 


### PR DESCRIPTION
We don't give the deployer user sudo rights on the server, so this patch is necessary to stop some of the commands that use sudo from trying to use it.
