### PR TITLE
Remove line 71 in tasks.rb to keep it from setting staging_domain to an empty string, regardless of config setting

### DIFF
--- a/lib/tasks.rb
+++ b/lib/tasks.rb
@@ -68,7 +68,6 @@ namespace :db do
 	end
 	desc "Sets the database credentials (and other settings) in wp-config.php"
 	task :make_config do
-		staging_domain ||= ''
 		{:'%%WP_STAGING_DOMAIN%%' => staging_domain, :'%%WP_STAGE%%' => stage, :'%%DB_NAME%%' => wpdb[stage][:name], :'%%DB_USER%%' => wpdb[stage][:user], :'%%DB_PASSWORD%%' => wpdb[stage][:password], :'%%DB_HOST%%' => wpdb[stage][:host]}.each do |k,v|
 			run "sed -i 's/#{k}/#{v}/' #{release_path}/wp-config.php", :roles => :web
 		end


### PR DESCRIPTION
My setup wouldn't work until I removed this line, because for
some reason, it sets staging_domain to an empty string no matter
what it's set to in config.rb. I don't know whether I was doing
something wrong or what, but removing line 71 from lib/tasks.rb worked
for me.

This isn't exactly a pull request I just figured it'd be an easier way
of showing you where I had a problem.
